### PR TITLE
UTC AttributeError w Datetime Module

### DIFF
--- a/elytra/core.py
+++ b/elytra/core.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+from datetime import timezone
 import functools
 import typing
 
@@ -42,7 +43,7 @@ class BetterResponse(aiohttp.ClientResponse):
 
 
 def utc_now() -> datetime.datetime:
-    return datetime.datetime.now(datetime.UTC)
+    return datetime.datetime.now(timezone.UTC)
 
 
 class ParsableBase:


### PR DESCRIPTION
Hey there, 

Caught a little hiccup in the code with the `utc_now()` function. Looks like it was trying to call something that doesn't exist.
Switched out `datetime.datetime.now(datetime.UTC)` with `datetime.now(timezone.utc)` instead.

Gave it a test, and I'm able to authenticate properly now!